### PR TITLE
Deprecated option --y4m specified, use -c y4m instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ docker build -t vsgan_tensorrt:latest .
 # run with a mounted folder
 docker run --privileged --gpus all -it --rm -v /home/Desktop/tensorrt:/workspace/tensorrt vsgan_tensorrt:latest
 # you can use it in various ways, ffmpeg example
-vspipe --y4m inference.py - | ffmpeg -i pipe: example.mkv
+vspipe -c y4m inference.py - | ffmpeg -i pipe: example.mkv
 ```
 
 If docker does not want to start, try this before you use docker:


### PR DESCRIPTION
Fixed this warning